### PR TITLE
Moved read of Shuffleboard Auto Parameters from AutoDrive command group to individual commands

### DIFF
--- a/src/main/cpp/commands/AutoDelay.cpp
+++ b/src/main/cpp/commands/AutoDelay.cpp
@@ -4,7 +4,7 @@
 
 #include "commands/AutoDelay.h"
 
-AutoDelay::AutoDelay(units::time::second_t seconds) : m_seconds(seconds) {
+AutoDelay::AutoDelay(DriveTrain *drivetrain) : m_driveTrain(drivetrain) {
   // Use addRequirements() here to declare subsystem dependencies.
   m_timer = frc::Timer(); 
 }
@@ -13,8 +13,9 @@ AutoDelay::AutoDelay(units::time::second_t seconds) : m_seconds(seconds) {
 void AutoDelay::Initialize() {
   m_timer.Reset();
   m_timer.Start();
-  #ifdef DEBUG
-    printf("AutoDelay::Initialize()\n");
+  m_seconds = (units::time::second_t)m_driveTrain->m_nte_a_DriveDelay.GetDouble(0.0); // Seconds delay before driving
+  #ifdef DEBUG && DEBUG == TRUE
+    printf("AutoDelay()::Initialize()\n");
   #endif
 }   
 

--- a/src/main/cpp/commands/AutoDrive.cpp
+++ b/src/main/cpp/commands/AutoDrive.cpp
@@ -18,17 +18,17 @@
 
 AutoDrive::AutoDrive(DriveTrain *drivetrain, Launcher *launcher) : m_driveTrain(drivetrain) {
 #if defined(ENABLE_DRIVETRAIN)
-  units::time::second_t a = .5_s; // FIXME: Temporary pending proper type conversion double -> second_t
+  // SHuffleboard parameters NOT refreshing this way. Moving them into the specific commands instead of
+  // passing them as arguments to the command seems to function as desired.
+  // units::time::second_t a = .5_s; // FIXME: Temporary pending proper type conversion double -> second_t
   // double a = m_driveTrain->m_nte_a_DriveDelay.GetDouble(0.0); // Drive delay (seconds)
-  double b = m_driveTrain->m_nte_b_DriveDistance.GetDouble(0.0); // Drive distance (inches)
-  double c = m_driveTrain->m_nte_c_DriveTurnAngle.GetDouble(0.0); // Turning Angle (degrees)
-  printf("Autodrive(): Reading parameters from Shuffleboard... %f\n", b);
+  // double c = m_driveTrain->m_nte_c_DriveTurnAngle.GetDouble(0.0); // Turning Angle (degrees)
 
   #if !defined(ENABLE_LAUNCHER)
   // Add your commands here, e.g.
   // AddCommands(FooCommand(), BarCommand());
   AddCommands (
-    frc2::SequentialCommandGroup { AutoDelay(a), AutoDriveDistance(drivetrain, b) }
+    frc2::SequentialCommandGroup { AutoDelay(drivetrain), AutoDriveDistance(drivetrain) }
     ); /* */
   #endif
   #if defined(ENABLE_LAUNCHER)

--- a/src/main/cpp/commands/AutoDriveDistance.cpp
+++ b/src/main/cpp/commands/AutoDriveDistance.cpp
@@ -5,7 +5,7 @@
 #include "commands/AutoDriveDistance.h"
 #include <frc/smartdashboard/SmartDashboard.h>
 
-AutoDriveDistance::AutoDriveDistance(DriveTrain *drivetrain, double distance) : m_driveTrain(drivetrain), m_distance_inches(distance){
+AutoDriveDistance::AutoDriveDistance(DriveTrain *drivetrain) : m_driveTrain(drivetrain) {
   // Use addRequirements() here to declare subsystem dependencies.
   AddRequirements(drivetrain);
 }
@@ -15,6 +15,7 @@ void AutoDriveDistance::Initialize() {
   m_driveTrain->ResetEncoders();
   // Send the distance travled to the dashboard
   m_driveTrain->m_nte_Testing.SetDouble(m_driveTrain->GetRightDistanceInches());
+  m_distance_inches = m_driveTrain->m_nte_b_DriveDistance.GetDouble(0.0);
 }
 
 // Called repeatedly when this Command is scheduled to run

--- a/src/main/include/commands/AutoDelay.h
+++ b/src/main/include/commands/AutoDelay.h
@@ -7,6 +7,7 @@
 #include <frc2/command/CommandBase.h>
 #include <frc2/command/CommandHelper.h>
 #include <frc/Timer.h>
+#include "subsystems/DriveTrain.h"
 
 /**
  * An example command.
@@ -18,7 +19,7 @@
 class AutoDelay
     : public frc2::CommandHelper<frc2::CommandBase, AutoDelay> {
  public:
-  explicit AutoDelay( units::time::second_t seconds);
+  explicit AutoDelay(DriveTrain *drivetrain);
 
   void Initialize() override;
 
@@ -29,6 +30,8 @@ class AutoDelay
   bool IsFinished() override;
 
  private:
+  DriveTrain *m_driveTrain;
   units::time::second_t m_seconds;
+  // double m_seconds; // Don't know how to type convert the NTE GetDouble() -> second_t
   frc::Timer m_timer;  
 };

--- a/src/main/include/commands/AutoDriveDistance.h
+++ b/src/main/include/commands/AutoDriveDistance.h
@@ -18,7 +18,7 @@
 class AutoDriveDistance
     : public frc2::CommandHelper<frc2::CommandBase, AutoDriveDistance> {
  public:
-  AutoDriveDistance(DriveTrain *drivetrain, double distance);
+  AutoDriveDistance(DriveTrain *drivetrain);
 
   void Initialize() override;
 
@@ -30,6 +30,6 @@ class AutoDriveDistance
 
  private:
   DriveTrain *m_driveTrain;
-  double m_distance_inches; 
+  double m_distance_inches; // CRE 2022-01-28 Read from shuffleboard NOT passed as argument
   double m_speedOut = 0.0;
 };


### PR DESCRIPTION
The reading of autonomous parameters (drive delay/drive distance/etc) from the shuffleboard was done in the AutoDrive.cpp command group. The desired input values were passed to the individual commands as arguments within the constructor, but this was not functional. I removed these from the AutoDrive command group and included the Shuffleboard reading in the individual subcommands in each command's Initialize() method. This appears to work as desired.