### PR TITLE
Add support for multiple autos, selectable by shuffleboard

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -76,7 +76,7 @@ void RobotContainer::TeleopInit() {
 }
 
 void RobotContainer::AutonomousInit() {
-  m_driveTrain.GetAutonomousDistance();
+  m_driveTrain.GetAutonomousParameters();
 }
 void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here

--- a/src/main/cpp/commands/AutoDrive.cpp
+++ b/src/main/cpp/commands/AutoDrive.cpp
@@ -30,29 +30,41 @@ AutoDrive::AutoDrive(DriveTrain *drivetrain, Launcher *launcher, Intake *intake)
   // double a = m_driveTrain->m_nte_a_DriveDelay.GetDouble(0.0); // Drive delay (seconds)
   // double c = m_driveTrain->m_nte_c_DriveTurnAngle.GetDouble(0.0); // Turning Angle (degrees)
 
-  double m_distance = m_driveTrain->m_nte_b_DriveDistance.GetDouble(ConAutoDriveDistance::DISTANCE);
-
+  double m_distance = m_driveTrain->m_autoDistance;
+  int m_mode = m_driveTrain->m_autoDriveMode;
+  // Remove the following to allow any mode
+  m_mode = ConDriveTrain::AUTONOMOUS_MODE_SHOOT_DELAY_MOVE;
   // Add your commands here, e.g.
   // AddCommands(FooCommand(), BarCommand());
-  AddCommands (
-    frc2::SequentialCommandGroup {  frc2::InstantCommand( [launcher] { launcher->LaunchBert(); }, { launcher }),
-                                    frc2::InstantCommand( [launcher] { launcher->LaunchErnie(); }, { launcher }),
-//                                    Launch(launcher),
-                                    AutoDelay(0.5_s),
-                                    frc2::InstantCommand( [launcher] { launcher->RetractBert(); }, { launcher }),
-                                    frc2::InstantCommand( [launcher] { launcher->RetractErnie(); }, { launcher }),
-                                    frc2::InstantCommand( [intake] { intake->Deploy(); }, { intake }),
-                                    AutoDriveDistance(drivetrain, m_distance),
-                                    frc2::InstantCommand( [intake] { intake->Stow(); }, {intake}),
-                                    AutoDelay(0.5_s),
-                                    AutoDriveDistance(drivetrain, -m_distance),
-                                    AutoDelay(0.25_s),
-                                    frc2::InstantCommand( [launcher] { launcher->LaunchBert(); }, { launcher }),
-                                    frc2::InstantCommand( [launcher] { launcher->LaunchErnie(); }, { launcher }),                                  
-                                    AutoDelay(0.5_s),
-                                    frc2::InstantCommand( [launcher] { launcher->RetractBert(); }, { launcher }),
-                                    frc2::InstantCommand( [launcher] { launcher->RetractErnie(); }, { launcher }),
-                                 } );
+  switch (m_mode) {
+    case ConDriveTrain::AUTONOMOUS_MODE_SHOOT_DELAY_MOVE:
+      AddCommands (
+        frc2::SequentialCommandGroup {
+            frc2::InstantCommand( [launcher] { launcher->LaunchBert(); }, { launcher }),
+            frc2::InstantCommand( [launcher] { launcher->LaunchErnie(); }, { launcher }),
+    //        Launch(launcher),
+            AutoDelay(0.5_s),
+            frc2::InstantCommand( [launcher] { launcher->RetractBert(); }, { launcher }),
+            frc2::InstantCommand( [launcher] { launcher->RetractErnie(); }, { launcher }),
+            frc2::InstantCommand( [intake] { intake->Deploy(); }, { intake }),
+            AutoDriveDistance(drivetrain, m_distance),
+            frc2::InstantCommand( [intake] { intake->Stow(); }, {intake}),
+            AutoDelay(0.5_s),
+            AutoDriveDistance(drivetrain, -m_distance),
+            AutoDelay(0.25_s),
+            frc2::InstantCommand( [launcher] { launcher->LaunchBert(); }, { launcher }),
+            frc2::InstantCommand( [launcher] { launcher->LaunchErnie(); }, { launcher }),                                  
+            AutoDelay(0.5_s),
+            frc2::InstantCommand( [launcher] { launcher->RetractBert(); }, { launcher }),
+            frc2::InstantCommand( [launcher] { launcher->RetractErnie(); }, { launcher }),
+          } );
+    break;
+
+    case ConDriveTrain::AUTONOMOUS_MODE_JUST_MOVE:
+    break;
+
+    case ConDriveTrain::AUTONOMOUS_MODE_5_BALL:
+    break;
   #if 0
   // Add autonomous drive & launcher commands
   AddCommands (
@@ -68,5 +80,7 @@ AutoDrive::AutoDrive(DriveTrain *drivetrain, Launcher *launcher, Intake *intake)
     */
   );
   #endif  // defined(ENABLE_LAUNCHER)
+
+  } // switch(mode)
 #endif // defined(ENABLE_DRIVETRAIN)
 }

--- a/src/main/cpp/subsystems/DriveTrain.cpp
+++ b/src/main/cpp/subsystems/DriveTrain.cpp
@@ -108,9 +108,10 @@ DriveTrain::DriveTrain() {
   m_nte_InputExponent       = m_sbt_DriveTrain->AddPersistent("Input Exponent", 1.0)        .WithSize(1, 1).WithPosition(0, 2).GetEntry();
 
   // Create widgets for AutoDrive
-  m_nte_a_DriveDelay        = m_sbt_DriveTrain->AddPersistent("a Launch Delay", ConAutoDriveDistance::LAUNCH_DELAY)         .WithSize(1, 1).WithPosition(3, 0).GetEntry();
-  m_nte_b_DriveDistance     = m_sbt_DriveTrain->AddPersistent("b Drive Distance", ConAutoDriveDistance::DISTANCE)    .WithSize(1, 1).WithPosition(3, 1).GetEntry();
-  m_nte_c_DriveTurnAngle     = m_sbt_DriveTrain->AddPersistent("c Turn Angle", 0.0)       .WithSize(1, 1).WithPosition(3, 2).GetEntry();
+  m_nte_a_DriveDelay     = m_sbt_DriveTrain->AddPersistent("a Launch Delay", ConDriveTrain::AUTONOMOUS_LAUNCH_DELAY).WithSize(1, 1).WithPosition(3, 0).GetEntry();
+  m_nte_b_DriveDistance  = m_sbt_DriveTrain->AddPersistent("b Drive Distance", ConDriveTrain::AUTONOMOUS_DISTANCE).WithSize(1, 1).WithPosition(3, 1).GetEntry();
+  m_nte_c_DriveTurnAngle = m_sbt_DriveTrain->AddPersistent("c Turn Angle", 0.0)       .WithSize(1, 1).WithPosition(3, 2).GetEntry();
+  m_nte_autoDriveMode    = m_sbt_DriveTrain->AddPersistent("AutoDrive Mode", ConDriveTrain::AUTONOMOUS_MODE_SHOOT_DELAY_MOVE).WithSize(1, 1).WithPosition(3, 3).GetEntry();
   //  m_nte_Testing     = m_sbt_DriveTrain->AddPersistent("Testing", 0.0)       .WithSize(1, 1).WithPosition(3, 3).GetEntry();
 
   // Display current encoder values
@@ -197,8 +198,9 @@ void DriveTrain::ResetGyro() {
   gyro->Reset();
 }																				 
 
-// Call GetAutonomousDistance() inside the AutonomousInit() method to read values from Shuffleboard
-void DriveTrain::GetAutonomousDistance() {
+// Call GetAutonomousParameters() inside the AutonomousInit() method to read values from Shuffleboard
+void DriveTrain::GetAutonomousParameters() {
+  m_autoDriveMode =  m_nte_autoDriveMode.GetDouble(ConDriveTrain::AUTONOMOUS_MODE_SHOOT_DELAY_MOVE);
   m_autoDistance = m_nte_b_DriveDistance.GetDouble(ConDriveTrain::AUTONOMOUS_DISTANCE);
 }
 // void DriveTrain::SetSafety(bool safety) { SetSafetyEnabled(safety);}

--- a/src/main/include/commands/AutoDriveDistance.h
+++ b/src/main/include/commands/AutoDriveDistance.h
@@ -8,10 +8,11 @@
 #include <frc2/command/CommandHelper.h>
 #include "subsystems/DriveTrain.h"
 
-namespace ConAutoDriveDistance {
-  constexpr double DISTANCE = 86; // Inches (negative is reverse) Needed to exit the 
-  constexpr double LAUNCH_DELAY = 0.5; // Seconds to delay between launch & drive
-}
+// Moved to DriveTrain.h
+// namespace ConAutoDriveDistance {
+//   constexpr double DISTANCE = 86; // Inches (negative is reverse) Needed to exit the 
+//   constexpr double LAUNCH_DELAY = 0.5; // Seconds to delay between launch & drive
+// }
 
 /**
  * An example command.

--- a/src/main/include/subsystems/DriveTrain.h
+++ b/src/main/include/subsystems/DriveTrain.h
@@ -20,7 +20,12 @@
 
 namespace ConDriveTrain {
     // Autonomous Constants
-    constexpr double AUTONOMOUS_DISTANCE = 80;
+    constexpr double AUTONOMOUS_DISTANCE = 80;  // Inches (negative is reverse) Needed to exit the 
+    constexpr double AUTONOMOUS_LAUNCH_DELAY = 0.5; // Seconds to delay between launch & drive
+    constexpr int AUTONOMOUS_MODE_SHOOT_DELAY_MOVE = 1;
+    constexpr int AUTONOMOUS_MODE_JUST_MOVE = 2;
+    constexpr int AUTONOMOUS_MODE_5_BALL = 3;
+
     // Motors
     constexpr int RIGHT_MOTOR_A_ID = 2;
     constexpr int RIGHT_MOTOR_B_ID = 4;
@@ -69,6 +74,7 @@ class DriveTrain : public frc2::SubsystemBase {
   nt::NetworkTableEntry m_nte_a_DriveDelay;
   nt::NetworkTableEntry m_nte_b_DriveDistance;
   nt::NetworkTableEntry m_nte_c_DriveTurnAngle;
+  nt::NetworkTableEntry m_nte_autoDriveMode;
   
 #ifdef ENABLE_DRIVETRAIN
   /**
@@ -103,9 +109,14 @@ class DriveTrain : public frc2::SubsystemBase {
   void GoToAngle(double angle);
   void ResetGyro();
 
-  void GetAutonomousDistance();
+  // Retrieve from dashboard, set member variables
+  void GetAutonomousParameters();
   //void SetSafety(bool safety);
   
+  // Autonomous drive parameters
+  double m_autoDistance = ConDriveTrain::AUTONOMOUS_DISTANCE;
+  double m_autoDriveMode = ConDriveTrain::AUTONOMOUS_MODE_SHOOT_DELAY_MOVE;
+
  private:
   // Components (e.g. motor controllers and sensors) should generally be
   // declared private and exposed only through public methods.
@@ -131,8 +142,6 @@ class DriveTrain : public frc2::SubsystemBase {
 
   // motor max RPM
   const double MaxRPM = 5700;
-
-  double m_autoDistance = ConDriveTrain::AUTONOMOUS_DISTANCE;
 
   // Drive encoders
   rev::SparkMaxRelativeEncoder m_rightEncoderA = m_rightMotorA.GetEncoder();


### PR DESCRIPTION
Added AutoDrive capability for multiple modes:
- read the auto mode from shuffleboard
- use a switch statement in the AutoDrive command to select one of three modes

Todo:
- location of parameters for widget placement on shuffleboard 
- actions/command groups for the new modes

Code should not behave differently until
- new actions/command groups have been added
- hardcoded setting of mode is removed  (`AutoDrive.cpp`)