### PR TITLE
Shuffleboard tweaks; Added Limelight PIP stream mode (UNTESTED)

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -78,8 +78,18 @@ void RobotContainer::TeleopInit() {
   m_launcher.SetupClose();
   m_climber.SetClimberSoftLimits();
   m_launcher.Retract();
+  // Set Limelight Camera options
+  m_vision.Init();
 }
 
+/*
+Uncomment this and add declaration in h file if we need live adjustments
+also call this method  from Robot::TelopPeriodic();
+
+void RobotContainer::TeleopPeriodic() {
+  m_launcher.SetLaunchSoftLimits();
+}
+*/
 void RobotContainer::AutonomousInit() {
   m_driveTrain.SetAutonomousParameters();
   m_launcher.SetLaunchSoftLimits();

--- a/src/main/cpp/subsystems/Vision.cpp
+++ b/src/main/cpp/subsystems/Vision.cpp
@@ -15,16 +15,23 @@ Vision::Vision() {
     m_nte_Align_I = m_sbt_Vision->AddPersistent("Vision I", 0.0)  .WithSize(1, 1).WithPosition(0, 1).GetEntry();;
     m_nte_Align_D = m_sbt_Vision->AddPersistent("Vision D", 100.0).WithSize(1, 1).WithPosition(0, 2).GetEntry();;
 
+}
+
+#ifdef ENABLE_VISION
+
+void Vision::Init() {
+    // Must be called later than constructor
 #ifdef ENABLE_VISION
     // If using Vision Tracking use the following:
     // LightOn();
     // m_nt_Limelight->PutNumber("camMode", ConVision::VISION_TRACKING);
     LightOff();
     m_nt_Limelight->PutNumber("camMode", ConVision::DRIVER_ONLY);
+    // Set PIP w/ secondary camera main view
+    m_nt_Limelight->PutNumber("stream", ConVision::PRIMARY_SECONDARY_PIP);
 #endif
 }
 
-#ifdef ENABLE_VISION
 // This method will be called once per scheduler run
 void Vision::Periodic() {}
 

--- a/src/main/include/subsystems/Climber.h
+++ b/src/main/include/subsystems/Climber.h
@@ -21,8 +21,8 @@ namespace ConClimber {
   constexpr bool NONINVERTED = false; //
   constexpr double CLIMB_SPEED = -1.0;  // Climb Motor Speed
   constexpr double DESCEND_SPEED = 1.0; // Descend Motor Speed
-  constexpr int SOFT_LIMIT_FWD = 2830; // Soft Limit Extension 5' 6" MAX height; Bar @ 60-1/4"
-  constexpr int SOFT_LIMIT_REV = 0;
+  constexpr int SOFT_LIMIT_FWD = 4784; // Soft Limit Extension 5' 6" MAX height; Bar @ 60-1/4"
+  constexpr int SOFT_LIMIT_REV = 200;
   constexpr int CURRENT_STALL_LIMIT = 80;
 
   //Servo

--- a/src/main/include/subsystems/DriveTrain.h
+++ b/src/main/include/subsystems/DriveTrain.h
@@ -21,7 +21,7 @@
 
 namespace ConDriveTrain {
     // Autonomous Constants
-    constexpr double AUTONOMOUS_DISTANCE = 150;  // 84.75 inches Needed to exit the launchpad 
+    constexpr double AUTONOMOUS_DISTANCE = 90;  // 84.75 inches Needed to exit the launchpad 
     constexpr double AUTONOMOUS_DRIVE_DELAY = 5.0; // Seconds to delay between launch & drive
     constexpr int AUTONOMOUS_MODE_2_BALL = 1;
     constexpr int AUTONOMOUS_MODE_LAUNCH_DELAY_MOVE = 2;

--- a/src/main/include/subsystems/Launcher.h
+++ b/src/main/include/subsystems/Launcher.h
@@ -15,16 +15,16 @@ namespace ConLauncher {
   constexpr int MOTOR_BERT_ID = 6;
   constexpr int MOTOR_ERNIE_ID = 1;
   // Starting point for Launcher soft limits
-  constexpr int BERT_FWD_LIMIT = 150;
-  constexpr int ERNIE_FWD_LIMIT = 195;
+  constexpr int BERT_FWD_LIMIT = 165;
+  constexpr int ERNIE_FWD_LIMIT = 155;
   constexpr int BERT_REV_LIMIT = 0;
-  constexpr int ERNIE_REV_LIMIT = 0;
+  constexpr int ERNIE_REV_LIMIT = 0;  
   constexpr int BERT_FAR_LIMIT = 150;
   constexpr int ERNIE_FAR_LIMIT = 150;
   constexpr double BERT_RAMP_RATE = .1;
   constexpr double ERNIE_RAMP_RATE = .1;
-  constexpr double BERT_POWER = .74;
-  constexpr double ERNIE_POWER = .7;
+  constexpr double BERT_POWER = .79;
+  constexpr double ERNIE_POWER = .76;
   constexpr double BERT_FAR_POWER = .75;
   constexpr double ERNIE_FAR_POWER = .75;
   constexpr int CURRENT_STALL_LIMIT = 80;

--- a/src/main/include/subsystems/Vision.h
+++ b/src/main/include/subsystems/Vision.h
@@ -26,6 +26,11 @@ namespace ConVision {
     constexpr int BLINK = 2;
     constexpr int OFF = 1;
 
+    // Stream: 1 = Primary only; 2 = Primary/2nd PIP; 3 = 2nd/Primary PIP
+    constexpr int PRIMARY_ONLY = 1;
+    constexpr int PRIMARY_SECONDARY_PIP = 2;
+    constexpr int SECONDARY_PRIMARY_PIP = 3;
+
     // Camera Mode: Write to NT "camMode"
     constexpr int DRIVER_ONLY = 1;
     constexpr int VISION_TRACKING = 0;
@@ -39,6 +44,8 @@ class Vision : public frc2::SubsystemBase {
   /**
    * Will be called periodically whenever the CommandScheduler runs.
    */
+  void Init();
+  
   void Periodic();
 
   double Align();
@@ -61,6 +68,8 @@ class Vision : public frc2::SubsystemBase {
   // Components (e.g. motor controllers and sensors) should generally be
   // declared private and exposed only through public methods.
   std::shared_ptr<nt::NetworkTable> m_nt_Limelight;
+  int m_LEDStatus;
+  int m_Stream;
 
  public:
   frc::ShuffleboardTab *m_sbt_Vision;


### PR DESCRIPTION
This revision is basically the final code used for the Western New England District competitions. The only addition to the competition code was the change to allow PIP streaming from the LimeLight, but this version was never deployed or tested.